### PR TITLE
Add test for the JP (X) issue, and a fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: setup for tests, including GHIDRA_HOME
+      run: cd test; ./setup_tests.sh >> "$GITHUB_ENV"
+    - name: run tests
+      run: cd test; ./run_tests.sh

--- a/data/languages/STM8.sinc
+++ b/data/languages/STM8.sinc
@@ -1026,11 +1026,13 @@ TwoOp:	(X_Y)		is op4_4=0xF & X_Y						{ export *:1 X_Y; }
 	addb(A, TwoOp);
 }
 # prefix	mode 1100	operand		JP operand		Low 16 bits of PC := operand, unconditional jump (modes 2 JP #imm8 and 3 JP addr8 reassigned, see below)
-:JP TwoOp			is op0_4=0xC ... & TwoOp {
+# opcode 0xFC, JP (X), does not work this way and is handled below as :JP TwoOpW.
+:JP TwoOp			is (op0_4=0xC & op4_4>0xA & op4_4<0xF) ... & TwoOp {
 	goto TwoOp;
 }
 # prefix	mode 1101	operand		CALL operand	Push 16-bit PC, low 16 bits of PC := operand (modes 2 CALL #imm8 and 3 CALL addr8 reassigned, see below)
-:CALL TwoOp		is op0_4=0xD ... & TwoOp {
+# opcode 0xFD, CALL (X), does not work this way and is handled below as :CALL TwoOpW.
+:CALL TwoOp		is (op0_4=0xD & op4_4>0xA & op4_4<0xF) ... & TwoOp {
 	local pc:2 = inst_next;
 	pushw(pc);
 	call TwoOp;
@@ -1067,12 +1069,21 @@ TwoOpW: (val8u, X_Y)	is op4_4=0xE & X_Y ; val8u			{ local addr:$(RAM_W) = zext(X
 # -/90	1111 opcode			OP (X/Y)			Indexed with no offset
 TwoOpW: (X_Y)			is op4_4=0xF & X_Y					{ export *:2 X_Y; }
 
-
 X_Y_LDW:	X			is (ctx_prefix=0x00 | ctx_prefix=0x92 | ctx_prefix=0x72) & X	{ export X; }
 X_Y_LDW:	Y			is (ctx_prefix=0x90 | ctx_prefix=0x91)					 & Y	{ export Y; }
 
 Y_X_LDW:	Y			is (ctx_prefix=0x00 | ctx_prefix=0x92 | ctx_prefix=0x72) & Y	{ export Y; }
 Y_X_LDW:	X			is (ctx_prefix=0x90 | ctx_prefix=0x91)					 & X	{ export X; }
+
+
+:JP X_Y			is (op0_4=0xC & op4_4=0xF) & X_Y {
+	goto [X_Y];
+}
+:CALL X_Y		is (op0_4=0xD & op4_4=0xF) & X_Y {
+	local pc:2 = inst_next;
+	pushw(pc);
+	call [X_Y];
+}
 
 
 # prefix	mode 0011	operand		CPW X/Y,operand	Compare X/Y - operand (16 bit); compare Y/X if operand mode is indexed by X/Y (opcodes D3, E3, F3)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,11 @@
+jpx0.asm
+jpx0.cdb
+jpx0.elf
+jpx0.lk
+jpx0.lst
+jpx0.map
+jpx0.rel
+jpx0.rst
+jpx0.sym
+testProject.gpr
+testProject.rep

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,4 @@
 test_prog.*
 testProject.*
+decompiled.c
+expected_decompilation.c

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,11 +1,2 @@
-jpx0.asm
-jpx0.cdb
-jpx0.elf
-jpx0.lk
-jpx0.lst
-jpx0.map
-jpx0.rel
-jpx0.rst
-jpx0.sym
-testProject.gpr
-testProject.rep
+test_prog.*
+testProject.*

--- a/test/DecompileHeadless.java
+++ b/test/DecompileHeadless.java
@@ -1,0 +1,57 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//Decompile an entire program
+// stolen from https://gitlab.com/CinCan/tools/-/blob/master/stable/ghidra-decompiler/DecompileHeadless.java
+import java.io.*;
+import java.util.*;
+
+import ghidra.app.script.GhidraScript;
+import ghidra.app.util.Option;
+import ghidra.app.util.exporter.CppExporter;
+import ghidra.app.decompiler.*;
+import ghidra.program.model.symbol.IdentityNameTransformer;
+public class DecompileHeadless extends GhidraScript {
+      
+    private void exportToC(DecompileResults results ) {
+        try {
+            ClangTokenGroup grp = results.getCCodeMarkup();
+            if(grp != null) {
+                File tmpFile = new File("/dev/stdout");
+                PrintWriter writer = new PrintWriter(new FileOutputStream(tmpFile));
+                PrettyPrinter printer = new PrettyPrinter(results.getFunction(), grp, new IdentityNameTransformer());
+                DecompiledFunction decompFunc = printer.print();
+                writer.write(decompFunc.getC());
+                writer.close();
+            }
+        }
+        catch (IOException e) {
+            System.out.println(e.getStackTrace());
+        }
+    }
+        
+    @Override
+    public void run() throws Exception {
+        var program = this.getCurrentProgram();
+        DecompInterface ifc = new DecompInterface();
+        ifc.openProgram(program);
+        for(var func : program.getFunctionManager().getFunctions(true)) {
+            var results = ifc.decompileFunction(func, 100000, null);
+            exportToC(results);
+        }
+    }
+
+
+}

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,0 +1,14 @@
+function compile_and_decompile {
+    rm -rf test_prog.*
+    cat > test_prog.c
+    sdcc -mstm8 test_prog.c --out-fmt-elf
+
+    # skip over the boilerplate and just show the code
+    sed -ne '/test_prog.c/, $ p' test_prog.lst
+    
+    rm -rf testProject.rep testProject.gpr
+    "$GHIDRA_HOME/support/analyzeHeadless" \
+        "$TEST_DIR" testProject \
+        -import test_prog.elf  -processor "STM8:BE:16:default" \
+        -scriptPath "$TEST_DIR" -postScript 'DecompileHeadless.java'
+}

--- a/test/jpx0.c
+++ b/test/jpx0.c
@@ -1,0 +1,9 @@
+int test_function(void) {
+  return 123;
+}
+
+int main(void) {
+  volatile int(*function)(void) = test_function;
+  function();
+  return function();
+}

--- a/test/jpx0.c
+++ b/test/jpx0.c
@@ -1,9 +1,0 @@
-int test_function(void) {
-  return 123;
-}
-
-int main(void) {
-  volatile int(*function)(void) = test_function;
-  function();
-  return function();
-}

--- a/test/preamble.h
+++ b/test/preamble.h
@@ -1,0 +1,6 @@
+#define undefined2 int
+#define undefined1 char
+typedef int code(void);
+#define _s_INITIALIZER &s_INITIALIZER
+#define bool char
+#define _main main

--- a/test/round_trip.c
+++ b/test/round_trip.c
@@ -1,0 +1,74 @@
+// Variable names are chosen to collide with what the decompiler will choose for
+// them in most cases. other patchups to make ghidra's decompilation output
+// compile successfully are handled in test_prog.h .
+undefined2 s_INITIALIZER(void)
+
+{
+  return 0x7b;
+}
+
+
+code * _get_fptr(void)
+
+{
+  return s_INITIALIZER;
+}
+
+
+undefined1 _get_char(void)
+
+{
+  return 1;
+}
+
+
+undefined2 _test_callx(void)
+
+{
+  code *pcVar1;
+  
+  pcVar1 = (code *)_get_fptr();
+  (*pcVar1)();
+  return 1;
+}
+
+
+void _test_jpx(void)
+
+{
+  code *UNRECOVERED_JUMPTABLE;
+  
+  UNRECOVERED_JUMPTABLE = (code *)_get_fptr();
+                    /* WARNING: Could not recover jumptable at 0x8039. Too many branches */
+                    /* WARNING: Treating indirect jump as call */
+  (*UNRECOVERED_JUMPTABLE)();
+  return;
+}
+
+
+undefined1 _test_tnz(void)
+
+{
+  char cVar1;
+  undefined1 uVar2;
+  
+  cVar1 = _get_char();
+  if (cVar1 == '\0') {
+    uVar2 = 0x10;
+  }
+  else {
+    uVar2 = 0x11;
+  }
+  return uVar2;
+}
+
+
+undefined2 _main(undefined2 param_1)
+
+{
+  _test_jpx();
+  _test_callx();
+  _test_tnz();
+  return param_1;
+}
+

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+set -euxo pipefail
+
+TEST_DIR="$(pwd)"
+export TEST_DIR
+for test in test_*.sh; do
+    "./$test" || echo "test $test failed: $?"
+done

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,6 +3,32 @@ set -euxo pipefail
 
 TEST_DIR="$(pwd)"
 export TEST_DIR
-for test in test_*.sh; do
-    "./$test" || echo "test $test failed: $?"
-done
+
+# start with preamble patching up types
+cat preamble.h > test_prog.c
+# remove indented comment-only lines
+# remove trailing comments
+sed '/^ *\/\//d; s@//.*@@;' round_trip.c > expected_decompilation.c
+# remove leading underscore from identifiers
+sed 's/\([) ]\)_/\1/g' expected_decompilation.c >> test_prog.c
+
+sdcc -mstm8 test_prog.c --out-fmt-elf \
+     --nogcse --noinvariant --noinduction --noloopreverse \
+     --no-peep
+
+
+
+
+# create decompiled.c with the decompiled functions
+rm -rf testProject.rep testProject.gpr
+"$GHIDRA_HOME/support/analyzeHeadless" \
+    "$TEST_DIR" testProject \
+    -import test_prog.elf  -processor "STM8:BE:16:default" \
+    -scriptPath "$TEST_DIR" -postScript 'DecompileHeadless.java'
+
+
+# skip the first lines containing the static initializer and _main stub, then
+# diff with original c code
+sed -ne '/s_INITIALIZER/,$ p' decompiled.c | diff -Naur expected_decompilation.c -
+
+echo "#### opcodes covered:"; cat test_prog.lst | grep -v '[;:]' | cut -c 14-30,42-|grep -v '^ .*\.' | sort -u 

--- a/test/setup_tests.sh
+++ b/test/setup_tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash 
+set -euxo pipefail
+TEST_DIR=$(pwd)
+export TEST_DIR
+
+# apparently github actions do not define TMPDIR
+TMPDIR=${TMPDIR:-/tmp}
+export TMPDIR
+
+# if GHIDRA_HOME is set, use it; otherwise set one up
+if [ -z "${GHIDRA_HOME:-}" ]; then
+    GHIDRA_HOME="$TMPDIR/ghidra_STM8_tests/ghidra_home"
+    export GHIDRA_HOME
+fi
+
+analyzeHeadless="$GHIDRA_HOME/support/analyzeHeadless"
+
+# if analyzeHeadless exists, use it; otherwise we need to install ghidra
+if [ ! -e "$analyzeHeadless" ]; then
+    # first download the zip if it isn't there already
+    ghidra_zip="$TMPDIR/ghidra.zip"
+    ghidra_url="https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.4.2_build/ghidra_11.4.2_PUBLIC_20250826.zip"
+    if [ ! -e "ghidra_zip" ]; then
+        curl --silent -L "$ghidra_url" --output "$ghidra_zip" 1>&2
+    fi
+
+    mkdir -p "$GHIDRA_HOME";
+    cd "$GHIDRA_HOME";
+    unzip -qq "$ghidra_zip" 1>&2;
+    # the ghidra zip file adds an extra directory layer; remove it
+    extra_dir="$(ls)"
+    (shopt -s dotglob; mv "$extra_dir"/* .)
+    rmdir "$extra_dir"
+fi
+
+# install extension with a symlink
+extensions_dir="$GHIDRA_HOME/Ghidra/Extensions"
+rmdir "$extensions_dir"
+ln -sf "$TEST_DIR/.." "$extensions_dir"
+
+# ensure sdcc enabled
+if ! which sdcc; then
+    sudo apt install -y sdcc 1>&2
+fi
+
+echo "GHIDRA_HOME=$GHIDRA_HOME"
+echo "TEST_DIR=$TEST_DIR"

--- a/test/test_jpx.sh
+++ b/test/test_jpx.sh
@@ -1,0 +1,16 @@
+#!/bin/bash 
+set -euxo pipefail
+
+rm -rf testProject.rep testProject.gpr
+
+sdcc -mstm8 jpx0.c --out-fmt-elf
+
+cat jpx0.lst
+
+analyzeHeadless="$GHIDRA_HOME/support/analyzeHeadless"
+
+"$analyzeHeadless" "$TEST_DIR" testProject -import jpx0.elf  -processor "STM8:BE:16:default" \
+                   -scriptPath "$TEST_DIR" -postScript     'DecompileHeadless.java'
+
+
+

--- a/test/test_jpx.sh
+++ b/test/test_jpx.sh
@@ -1,16 +1,15 @@
 #!/bin/bash 
 set -euxo pipefail
 
-rm -rf testProject.rep testProject.gpr
+source common.sh
+compile_and_decompile <<EOF
+int test_function(void) {
+  return 123;
+}
 
-sdcc -mstm8 jpx0.c --out-fmt-elf
-
-cat jpx0.lst
-
-analyzeHeadless="$GHIDRA_HOME/support/analyzeHeadless"
-
-"$analyzeHeadless" "$TEST_DIR" testProject -import jpx0.elf  -processor "STM8:BE:16:default" \
-                   -scriptPath "$TEST_DIR" -postScript     'DecompileHeadless.java'
-
-
-
+int main(void) {
+  volatile int(*function)(void) = test_function;
+  function();
+  return function();
+}
+EOF

--- a/test/test_tnz.sh
+++ b/test/test_tnz.sh
@@ -1,0 +1,16 @@
+#!/bin/bash 
+set -euxo pipefail
+
+source common.sh
+compile_and_decompile <<EOF
+char test_function(void) {
+  return 1;
+}
+
+int main(void) {
+  if (test_function() == 0) {
+    return 0;
+  }
+  return 1;
+}
+EOF


### PR DESCRIPTION
Hi! I thought I would take a crack at fixing #9 since I think my project is blocked on the same issue.

I started by throwing together a simple command-line test runner based on @GaryOderNichts 's helpful demonstration code. The test compiles the code, shows its assembly listing so you can confirm that it includes both `CALL (X)` and `JP (X)`, then runs a headless Ghidra script to attempt to decompile it.

I also added a Github Actions wrapper script, so that you can see the output without having to run it yourself:
[Not a valid Address on instruction at 802e](https://github.com/abliss/ghidra_STM8/actions/runs/17366187731/job/49293343246#step:4:192) . I think that when the decompiler hits the `0xFD CALL (X)` instruction at `8008`, X holds `0x0000`, but instead of calling to the function at that address, it does something weird like loading one byte of that address, and then trying to call to the "unique" register "address" of `X` itself. This matches what I see in my own Ghidra when I enable p-code debugging. The resultant decompile contains no code for the `_main()` because decompilation hits this error and stops.

Next, I tried to make a fix. I read through the sleigh documentation but found it pretty confusing. I tried moving `CALL (X_Y)` and `JP (X_Y)` down below `TwoOpW` and changing `goto X_Y` to `goto (X_Y)`, and I think it worked, because the error goes away and you can now see a correct (I think) decompilation in 
[the test output](https://github.com/abliss/ghidra_STM8/actions/runs/17366205816/job/49293390015#step:4:260):
```
void _main(void) {
  (*_s_INITIALIZER)();
                    /* WARNING: Could not recover jumptable at 0x802e. Too many branches */
                    /* WARNING: Treating indirect jump as call */
  (*_s_INITIALIZER)();
  return;
}
```

I suspect, but have not tested, that the fix also does the right thing with `CALL (Y)` (the reason @konvikkor originally opened #9). However, I am very unsure whether my fix is the right way to do it, and I worry that I may have broken other opcodes  in the process. Perhaps @esaulenka can tell just by looking at my sleigh diff. But another possibility would be to build out the test suite with a bunch more examples to gain confidence. Perhaps we could even enumerate all possible opcodes and attempt to achieve complete coverage.

The test script is currently pretty quick & dirty. @esaulenka , if you think that this is a good direction to head in but you want to see it cleaned up some more, let me know and I'd be happy to spend a little more time on it. Or, if you think this is the wrong direction, I'd love to hear any alternate suggestions you might have.

Thanks for looking!